### PR TITLE
[DO NOT MERGE] Shows how to add intermediate serialization

### DIFF
--- a/seaice/main.F
+++ b/seaice/main.F
@@ -26,7 +26,7 @@ program test
     integer :: ser_count, ser_count_max
     character(len=6) :: ser_count_str
 
-    ser_count_max = 10
+    ser_count_max = 19
     num_tiles = 6
 
     ! initialize

--- a/seaice/main.F
+++ b/seaice/main.F
@@ -75,8 +75,12 @@ program test
         !$ser data snwdph=snwdph qsurf=qsurf snowmt=snowmt
         !$ser data gflux=gflux cmm=cmm chh=chh evap=evap hflx=hflx
 
-        write(*,*) tile, ser_count, iter, maxval(hice)
-
+        !$ser mode write
+        !$ser verbatim if (iter == 1) then
+        !$ser savepoint "sfc_sice-inside-iter1-"//trim(ser_count_str)
+        !$ser verbatim else
+        !$ser savepoint "sfc_sice-inside-iter2-"//trim(ser_count_str)
+        !$ser verbatim end if
         call sfc_sice                                                  &
             !  ---  inputs:
             ( im, km, ps, t1, q1, delt,                                &

--- a/seaice/main.py
+++ b/seaice/main.py
@@ -5,8 +5,8 @@ import sys
 import numpy as np
 import sea_ice as si
 
-#SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
-SERIALBOX_DIR = "/usr/local/serialbox/"
+SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
+#SERIALBOX_DIR = "/usr/local/serialbox/"
 sys.path.append(SERIALBOX_DIR + "/python")
 import serialbox as ser
 
@@ -21,8 +21,8 @@ OUT_VARS = ["hice", "fice", "tice", "weasd", "tskin", "tprcp", "stc", \
             "ep", "snwdph", "qsurf", "snowmt", "gflux", "cmm", "chh", \
             "evap", "hflx"]
 
-#SELECT_SP = None
-SELECT_SP = {"tile": 5, "savepoint": "sfc_sice-in-iter1-000001"}
+SELECT_SP = None
+#SELECT_SP = {"tile": 5, "savepoint": "sfc_sice-in-iter1-000001"}
 
 
 def data_dict_from_var_list(var_list, serializer, savepoint):

--- a/seaice/main.py
+++ b/seaice/main.py
@@ -5,8 +5,8 @@ import sys
 import numpy as np
 import sea_ice as si
 
-SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
-#SERIALBOX_DIR = "/usr/local/serialbox/"
+#SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
+SERIALBOX_DIR = "/usr/local/serialbox/"
 sys.path.append(SERIALBOX_DIR + "/python")
 import serialbox as ser
 
@@ -21,12 +21,16 @@ OUT_VARS = ["hice", "fice", "tice", "weasd", "tskin", "tprcp", "stc", \
             "ep", "snwdph", "qsurf", "snowmt", "gflux", "cmm", "chh", \
             "evap", "hflx"]
 
+#SELECT_SP = None
+SELECT_SP = {"tile": 5, "savepoint": "sfc_sice-in-iter1-000001"}
+
 
 def data_dict_from_var_list(var_list, serializer, savepoint):
     d = {}
     for var in var_list:
         d[var] = serializer.read(var, savepoint)
     return d
+
 
 def compare_data(exp_data, ref_data):
     assert set(exp_data.keys()) == set(ref_data.keys()), \
@@ -35,7 +39,12 @@ def compare_data(exp_data, ref_data):
         assert np.allclose(exp_data[key], ref_data[key], equal_nan=True), \
             "Data does not match for field " + key
 
+
 for tile in range(6):
+
+    if SELECT_SP is not None:
+        if tile != SELECT_SP["tile"]:
+            continue
 
     serializer = ser.Serializer(ser.OpenModeKind.Read, "./data", "Generator_rank" + str(tile))
 
@@ -43,6 +52,11 @@ for tile in range(6):
 
     isready = False
     for sp in savepoints:
+
+        if SELECT_SP is not None:
+            if sp.name != SELECT_SP["savepoint"] and \
+               sp.name != SELECT_SP["savepoint"].replace("-in-", "-out-"):
+                continue
 
         if sp.name.startswith("sfc_sice-in"):
 
@@ -70,6 +84,6 @@ for tile in range(6):
             ref_data = data_dict_from_var_list(OUT_VARS, serializer, sp)
 
             # check result
-            compare_data(out_data, ref_data)
+            #compare_data(out_data, ref_data)
 
             isready = False

--- a/seaice/main.py
+++ b/seaice/main.py
@@ -5,8 +5,8 @@ import sys
 import numpy as np
 import sea_ice as si
 
-SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
-#SERIALBOX_DIR = "/usr/local/serialbox/"
+#SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
+SERIALBOX_DIR = "/usr/local/serialbox/"
 sys.path.append(SERIALBOX_DIR + "/python")
 import serialbox as ser
 
@@ -67,6 +67,13 @@ for tile in range(6):
 
             # read serialized input data
             in_data = data_dict_from_var_list(IN_VARS, serializer, sp)
+
+            # TODO: remove once we validate
+            # attach meta-info for debugging purposes
+            ser_inside = ser.Serializer(ser.OpenModeKind.Read, "./data", "Serialized_rank" + str(tile))
+            sp_inside = ser_inside.savepoint[sp.name.replace("-in-", "-inside-")]
+            in_data["serializer"] = ser_inside
+            in_data["savepoint"] = sp_inside
 
             # run Python version
             out_data = si.run(in_data)

--- a/seaice/main.py
+++ b/seaice/main.py
@@ -58,7 +58,6 @@ for tile in range(6):
             out_data = si.run(in_data)
 
             isready = True
-            del ref_data
 
         if sp.name.startswith("sfc_sice-out"):
 
@@ -74,4 +73,3 @@ for tile in range(6):
             compare_data(out_data, ref_data)
 
             isready = False
-            del in_data, out_data, ref_data

--- a/seaice/sea_ice.py
+++ b/seaice/sea_ice.py
@@ -7,6 +7,6 @@ OUT_VARS = ["tskin", "tprcp", "fice", "gflux", "ep", "stc", "tice", \
     "hice", "cmm"]
 
 def run(in_dict):
-        
+
     # TODO - implement sea-ice model
     return {key: in_dict.get(key, None) for key in OUT_VARS}

--- a/seaice/sea_ice.py
+++ b/seaice/sea_ice.py
@@ -8,5 +8,9 @@ OUT_VARS = ["tskin", "tprcp", "fice", "gflux", "ep", "stc", "tice", \
 
 def run(in_dict):
 
+    ser = in_dict["serializer"]
+    sp = in_dict["savepoint"]
+    stsice = ser.read("stsice", sp)
+
     # TODO - implement sea-ice model
     return {key: in_dict.get(key, None) for key in OUT_VARS}

--- a/seaice/sfc_sice.F
+++ b/seaice/sfc_sice.F
@@ -300,12 +300,14 @@
         endif
       enddo
 
+      !$ser data  fice=fice flag=flag hfi=hfi hfd=hfd sneti=sneti focn=focn delt=delt lprnt=lprnt ipr=ipr
       call ice3lay                                                      &
 !  ---  inputs:                                                         !
      &     ( im, kmi, fice, flag, hfi, hfd, sneti, focn, delt,          &
      &       lprnt, ipr,                                                &
 !  ---  outputs:                                                        !
      &       snowd, hice, stsice, tice, snof, snowmt, gflux )           !
+      !$ser data snowd=snowd hice=hice stsice=stsice tice=tice snof=snof snowmt=snowmt gflux=gflux
 
       do i = 1, im
         if (flag(i)) then


### PR DESCRIPTION
This is a draft PR to demonstrate how to add intermediate serialization points inside the physical parametrization.
- Set mode to write before calling parametrization and setup a new savepoint.
- Add serialization statements inside physical parametrization.
- Compile & run.
- Will generate additional serialized data in `./data`.
- Data can be read by setting up a new Python serializer...
```Python
    serializer = ser.Serializer(ser.OpenModeKind.Read, "./data", "Serialized_rank" + str(tile))
    sp = serializer.savepoint['sfc_sice-inside-iter2-000007']
    fice = serializer.read("fice", sp)
```