### PR TITLE
[DO NOT MERGE] Shows how to add intermediate serialization

### DIFF
--- a/seaice/main.F
+++ b/seaice/main.F
@@ -75,8 +75,6 @@ program test
         !$ser data snwdph=snwdph qsurf=qsurf snowmt=snowmt
         !$ser data gflux=gflux cmm=cmm chh=chh evap=evap hflx=hflx
 
-        write(*,*) tile, ser_count, iter, maxval(hice)
-
         call sfc_sice                                                  &
             !  ---  inputs:
             ( im, km, ps, t1, q1, delt,                                &

--- a/seaice/main.F
+++ b/seaice/main.F
@@ -75,6 +75,12 @@ program test
         !$ser data snwdph=snwdph qsurf=qsurf snowmt=snowmt
         !$ser data gflux=gflux cmm=cmm chh=chh evap=evap hflx=hflx
 
+        !$ser mode write
+        !$ser verbatim if (iter == 1) then
+        !$ser savepoint "sfc_sice-inside-iter1-"//trim(ser_count_str)
+        !$ser verbatim else
+        !$ser savepoint "sfc_sice-inside-iter2-"//trim(ser_count_str)
+        !$ser verbatim end if
         call sfc_sice                                                  &
             !  ---  inputs:
             ( im, km, ps, t1, q1, delt,                                &

--- a/seaice/main.py
+++ b/seaice/main.py
@@ -5,8 +5,8 @@ import sys
 import numpy as np
 import sea_ice as si
 
-SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
-#SERIALBOX_DIR = "/usr/local/serialbox/"
+#SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
+SERIALBOX_DIR = "/usr/local/serialbox/"
 sys.path.append(SERIALBOX_DIR + "/python")
 import serialbox as ser
 

--- a/seaice/main.py
+++ b/seaice/main.py
@@ -5,8 +5,8 @@ import sys
 import numpy as np
 import sea_ice as si
 
-SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
-#SERIALBOX_DIR = "/usr/local/serialbox/"
+#SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
+SERIALBOX_DIR = "/usr/local/serialbox/"
 sys.path.append(SERIALBOX_DIR + "/python")
 import serialbox as ser
 
@@ -67,6 +67,13 @@ for tile in range(6):
 
             # read serialized input data
             in_data = data_dict_from_var_list(IN_VARS, serializer, sp)
+
+            # TODO: remove once we validate
+            # attach meta-info for debugging purposes
+            ser_inside = ser.Serializer(ser.OpenModeKind.Read, "./data", "Serialized_rank" + str(tile))
+            sp_inside = ser_inside.savepoint[sp.name.replace("-in-", "-inside-")]
+            in_data["serializer"] = ser_inside
+            in_data["savepoint"] = sp_inside
 
             # run Python version
             out_data = si.run(in_data)

--- a/seaice/main.py
+++ b/seaice/main.py
@@ -5,8 +5,8 @@ import sys
 import numpy as np
 import sea_ice as si
 
-#SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
-SERIALBOX_DIR = "/usr/local/serialbox/"
+SERIALBOX_DIR = "/project/c14/install/daint/serialbox2_master/gnu_debug"
+#SERIALBOX_DIR = "/usr/local/serialbox/"
 sys.path.append(SERIALBOX_DIR + "/python")
 import serialbox as ser
 

--- a/seaice/sea_ice.py
+++ b/seaice/sea_ice.py
@@ -8,5 +8,9 @@ OUT_VARS = ["tskin", "tprcp", "fice", "gflux", "ep", "stc", "tice", \
 
 def run(in_dict):
 
+    ser = in_dict["serializer"]
+    sp = in_dict["savepoint"]
+    stsice = ser.read("stsice", sp)
+
     # TODO - implement sea-ice model
     return {key: in_dict.get(key, None) for key in OUT_VARS}

--- a/seaice/sfc_sice.F
+++ b/seaice/sfc_sice.F
@@ -300,12 +300,14 @@
         endif
       enddo
 
+      !$ser data  fice=fice flag=flag hfi=hfi hfd=hfd sneti=sneti focn=focn delt=delt lprnt=lprnt ipr=ipr
       call ice3lay                                                      &
 !  ---  inputs:                                                         !
      &     ( im, kmi, fice, flag, hfi, hfd, sneti, focn, delt,          &
      &       lprnt, ipr,                                                &
 !  ---  outputs:                                                        !
      &       snowd, hice, stsice, tice, snof, snowmt, gflux )           !
+      !$ser data snowd=snowd hice=hice stsice=stsice tice=tice snof=snof snowmt=snowmt gflux=gflux
 
       do i = 1, im
         if (flag(i)) then


### PR DESCRIPTION
This is a draft PR to demonstrate how to add intermediate serialization points inside the physical parametrization.
- Set mode to write before calling parametrization and setup a new savepoint.
- Add serialization statements inside physical parametrization.
- Compile & run.
- Will generate additional serialized data in `./data`.
- Data can be read by setting up a new Python serializer...
```Python
    serializer = ser.Serializer(ser.OpenModeKind.Read, "./data", "Serialized_rank" + str(tile))
    sp = serializer.savepoint['sfc_sice-inside-iter2-000007']
    fice = serializer.read("fice", sp)
```