### PR TITLE
Clarify docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ You need the following things installed if you want to run directly on the host 
 
 ## Running
 
+First time only, if you run inside a docker container:
+
+```bash
+./build.sh
+```
+
+After that:
+
 ```bash
 ./enter.sh # only if you are running using the Docker environment
 cd XXX
@@ -21,9 +29,9 @@ make
 
 Note: You may have to adapt the `Makefile` to point to your serialbox installation if it is not installed under `/usr/local/serialbox`.
 
-## Docker environment
+## Running without docker
 
-If you prefer to work in a Docker environment, simply type `./build.sh` to build a Docker image that contains everything you need and `./enter` to enter the image with the correct mounted directories to work on the standalone codes.
+If you prefer to work without a Docker environment, you can ignore the `./build.sh` and `./enter.sh` commands.
 
 ## Code coverage
 


### PR DESCRIPTION
This PR shifts the information on how to build the docker image to come before the command to enter the image, to avoid the situation where a new user tries to run an image which does not yet exist.